### PR TITLE
Add convTranspose2d implementation.

### DIFF
--- a/src/conv2d.js
+++ b/src/conv2d.js
@@ -12,17 +12,20 @@ import {transpose} from './transpose.js';
  * @param {MLConv2dOptions} options
  * @return {Tensor}
  */
-export function conv2d(input, filter, {padding = [0, 0, 0, 0],
-  strides = [1, 1],
-  groups = 1,
-  dilations = [1, 1],
-  activation = (x) => x,
-  inputLayout = 'nchw',
-  filterLayout = 'oihw',
-  bias,
-  autoPad = 'explicit',
-}
-= {}) {
+export function conv2d(
+    input,
+    filter,
+    {
+      padding = [0, 0, 0, 0],
+      strides = [1, 1],
+      groups = 1,
+      dilations = [1, 1],
+      activation = (x) => x,
+      inputLayout = 'nchw',
+      filterLayout = 'oihw',
+      bias,
+      autoPad = 'explicit',
+    } = {}) {
   if (inputLayout === 'nhwc') {
     // nhwc -> nchw
     input = transpose(input, {permutation: [0, 3, 1, 2]});
@@ -43,8 +46,8 @@ export function conv2d(input, filter, {padding = [0, 0, 0, 0],
   const [outputChannels, , filterHeight, filterWidth] = filter.shape;
   const [strideHeight, strideWidth] = strides;
   const [dilationHeight, dilationWidth] = dilations;
-  const effectiveFilterHeight = filterHeight + (filterHeight - 1) * (dilationHeight - 1);
-  const effectiveFilterWidth = filterWidth + (filterWidth - 1) * (dilationWidth - 1);
+  const effectiveFilterHeight = (filterHeight - 1) * dilationHeight + 1;
+  const effectiveFilterWidth = (filterWidth - 1) * dilationWidth + 1;
 
   let beginningPaddingHeight;
   let endingPaddingHeight;

--- a/src/conv_transpose2d.js
+++ b/src/conv_transpose2d.js
@@ -93,10 +93,13 @@ export function convTranspose2d(input, filter, {padding = [0, 0, 0, 0],
   let output = new Tensor(outputShape);
 
   // using conv2d logic to compute convTranspose2d
+
+  // real padding = dilation * (kernel_size - 1) - padding, referring to
+  //   https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html
   const realBeginningPaddingHeight =
-    filter.shape[2] - beginningPaddingHeight + (dilationHeight - 1) * 2 - 1;
+    dilationHeight * (filter.shape[2] - 1) - beginningPaddingHeight;
   const realBeginningPaddingWidth =
-    filter.shape[3] - beginningPaddingWidth + (dilationWidth - 1) * 2 - 1;
+    dilationWidth * (filter.shape[3] - 1) - beginningPaddingWidth;
   const [realStrideHeight, realStrideWidth] = [1, 1];
 
   const outputChannelsPerGroup = outputChannels / groups;

--- a/src/conv_transpose2d.js
+++ b/src/conv_transpose2d.js
@@ -1,0 +1,177 @@
+'use strict';
+
+import {Tensor} from './lib/tensor.js';
+import {validateConv2dParams} from './lib/validate-input.js';
+import {computePaddingForAutoPad} from './lib/compute-padding.js';
+import {transpose} from './transpose.js';
+
+/**
+ * Compute a 2-D transposed convolution given 4-D input and filter tensors.
+ * @param {Tensor} input
+ * @param {Tensor} filter
+ * @param {MLConvTranspose2dOptions} options
+ * @return {Tensor}
+ */
+export function convTranspose2d(input, filter, {padding = [0, 0, 0, 0],
+  strides = [1, 1],
+  groups = 1,
+  dilations = [1, 1],
+  outputPadding = [0, 0],
+  outputSizes,
+  activation = (x) => x,
+  inputLayout = 'nchw',
+  filterLayout = 'iohw',
+  bias,
+  autoPad = 'explicit',
+}
+= {}) {
+  if (inputLayout === 'nhwc') {
+    // nhwc -> nchw
+    input = transpose(input, {permutation: [0, 3, 1, 2]});
+  }
+  if (filterLayout === 'iohw') {
+    // iohw -> oihw
+    filter = transpose(filter, {permutation: [1, 0, 2, 3]});
+  } else if (filterLayout === 'hwoi') {
+    // hwoi -> oihw
+    filter = transpose(filter, {permutation: [2, 3, 0, 1]});
+  } else if (filterLayout === 'ohwi') {
+    // ohwi -> oihw
+    filter = transpose(filter, {permutation: [0, 3, 1, 2]});
+  }
+
+  validateConv2dParams(input, filter, {groups, bias});
+
+  const [batchCount, inputChannels, inputHeight, inputWidth] = input.shape;
+  const [outputChannels, , filterHeight, filterWidth] = filter.shape;
+  const [strideHeight, strideWidth] = strides;
+  const [dilationHeight, dilationWidth] = dilations;
+  const effectiveFilterHeight = filterHeight + (filterHeight - 1) * (dilationHeight - 1);
+  const effectiveFilterWidth = filterWidth + (filterWidth - 1) * (dilationWidth - 1);
+
+  let beginningPaddingHeight;
+  let endingPaddingHeight;
+  let beginningPaddingWidth;
+  let endingPaddingWidth;
+
+  if (autoPad === 'explicit') {
+    [beginningPaddingHeight, endingPaddingHeight, beginningPaddingWidth, endingPaddingWidth] =
+      padding;
+  } else {
+    // If outputSizes was given, there's no need to compute beginningPaddingHeight
+    // and endingPaddingHeight for same-upper or same-lower autoPad
+    if (outputSizes === undefined) {
+      [beginningPaddingHeight, endingPaddingHeight] = computePaddingForAutoPad(
+          autoPad, inputHeight, effectiveFilterHeight, strideHeight, outputPadding[0]);
+      [beginningPaddingWidth, endingPaddingWidth] = computePaddingForAutoPad(
+          autoPad, inputWidth, effectiveFilterWidth, strideWidth, outputPadding[1]);
+    }
+  }
+
+  const outputShape = new Array(4);
+  let outputHeight;
+  let outputWidth;
+  outputShape[0] = batchCount;
+  outputShape[1] = outputChannels;
+
+  if (outputSizes === undefined) {
+    // output size = (input size - 1) * stride + filter size + (filter size - 1) * (dilation - 1) -
+    //               beginning padding - ending padding + output padding
+    outputHeight =
+      (inputHeight - 1) * strideHeight + effectiveFilterHeight - beginningPaddingHeight -
+       endingPaddingHeight + outputPadding[0];
+    outputWidth =
+      (inputWidth - 1) * strideWidth + effectiveFilterWidth - beginningPaddingWidth -
+      endingPaddingWidth + outputPadding[1];
+  } else {
+    outputHeight = outputSizes[0];
+    outputWidth = outputSizes[1];
+  }
+
+  outputShape[2] = outputHeight;
+  outputShape[3] = outputWidth;
+  let output = new Tensor(outputShape);
+
+  // using conv2d logic to compute convTranspose2d
+  const realBeginningPaddingHeight =
+    filter.shape[2] - beginningPaddingHeight + (dilationHeight - 1) * 2 - 1;
+  const realBeginningPaddingWidth =
+    filter.shape[3] - beginningPaddingWidth + (dilationWidth - 1) * 2 - 1;
+  const [realStrideHeight, realStrideWidth] = [1, 1];
+
+  const outputChannelsPerGroup = outputChannels / groups;
+  const inputChannelsPerGroup = inputChannels / groups;
+
+  for (let ib = 0; ib < batchCount; ++ib) {
+    for (let g = 0; g < groups; ++g) {
+      for (let oc = 0; oc < outputChannelsPerGroup; ++oc) {
+        for (let ic = 0; ic < inputChannelsPerGroup; ++ic) {
+          for (let ih = -realBeginningPaddingHeight, oh = 0; oh < outputHeight;
+            ih += realStrideHeight, ++oh) {
+            for (let iw = -realBeginningPaddingWidth, ow = 0; ow < outputWidth;
+              iw += realStrideWidth, ++ow) {
+              const effectiveOutputChannel = oc + g * outputChannelsPerGroup;
+              const outputLocation = [ib, effectiveOutputChannel, oh, ow];
+              // make filter rotate 180
+              for (let kh = filterHeight + (filterHeight - 1) * (dilationHeight - 1) - 1;
+                kh >= 0; --kh) {
+                for (let kw = filterWidth + (filterWidth - 1) * (dilationWidth - 1) - 1;
+                  kw >= 0; --kw) {
+                  const realKh = kh / dilationHeight;
+                  const realKw = kw / dilationWidth;
+                  const realIh = Math.floor((ih + kh)/ strideHeight);
+                  const realIw = Math.floor((iw + kw)/ strideWidth);
+                  if (realIh < 0 || realIh >= inputHeight ||
+                    realIw < 0 || realIw >= inputWidth ||
+                    (strideHeight > 1 && (ih + kh) % strideHeight !== 0) ||
+                    (strideWidth > 1 && (iw + kw) % strideWidth !== 0) ||
+                    (dilationHeight > 1 && kh % dilationHeight !==0) ||
+                    (dilationWidth > 1 && kw % dilationWidth !==0)) {
+                    // Skip the padding values.
+                    continue;
+                  } else {
+                    const effectiveInputChannel = ic + g * inputChannelsPerGroup;
+                    const inputValue = input.getValueByLocation(
+                        [ib, effectiveInputChannel, realIh, realIw]);
+                    // make filter rotate 180
+                    const filterValue = filter.getValueByLocation(
+                        [effectiveOutputChannel, ic, filterHeight - realKh - 1,
+                          filterWidth - realKw - 1]);
+                    let outputValue = output.getValueByLocation(outputLocation);
+                    outputValue += inputValue * filterValue;
+                    output.setValueByLocation(outputLocation, outputValue);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (bias) {
+    for (let ib = 0; ib < batchCount; ++ib) {
+      for (let oc = 0; oc < outputChannels; ++oc) {
+        for (let oh = 0; oh < outputHeight; ++oh) {
+          for (let ow = 0; ow < outputWidth; ++ow) {
+            const outputLocation = [ib, oc, oh, ow];
+            const biasValue = bias.getValueByLocation([oc]);
+            let outputValue = output.getValueByLocation(outputLocation);
+            outputValue += biasValue;
+            output.setValueByLocation(outputLocation, outputValue);
+          }
+        }
+      }
+    }
+  }
+
+  output = activation(output);
+
+  if (inputLayout === 'nhwc') {
+    // nchw -> nhwc
+    output = transpose(output, {permutation: [0, 2, 3, 1]});
+  }
+
+  return output;
+}

--- a/src/lib/compute-padding.js
+++ b/src/lib/compute-padding.js
@@ -4,12 +4,27 @@
  * @param {Number} inputSize
  * @param {Number} effectiveFilterSize
  * @param {Number} stride
+ * @param {Number} outputPadding
  * @return {Array} [paddingBegin, paddingEnd]
  */
-export function computePaddingForAutoPad(autoPad, inputSize, effectiveFilterSize, stride) {
-  const outSize = Math.ceil(inputSize / stride);
-  const neededInput = (outSize - 1) * stride + effectiveFilterSize;
-  const totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
+export function computePaddingForAutoPad(
+    autoPad, inputSize, effectiveFilterSize, stride, outputPadding) {
+  let totalPadding;
+  if (outputPadding === undefined) {
+    // for conv2d
+    const outSize = Math.ceil(inputSize / stride);
+    const neededInput = (outSize - 1) * stride + effectiveFilterSize;
+    totalPadding = neededInput > inputSize ? neededInput - inputSize : 0;
+  } else {
+    // for convTranspose2d
+    // totalPadding = beginning padding + ending padding
+    // SAME_UPPER or SAME_LOWER mean pad the input so that
+    //   output size = input size * strides
+    // output size = (input size - 1) * stride + effectiveFilterSize
+    //     - beginning padding - ending padding + output padding
+    totalPadding = (inputSize - 1) * stride + effectiveFilterSize + outputPadding -
+      inputSize * stride;
+  }
   let paddingBegin;
   let paddingEnd;
   switch (autoPad) {

--- a/test/conv_transpose2d_test.js
+++ b/test/conv_transpose2d_test.js
@@ -1,0 +1,584 @@
+'use strict';
+
+import {convTranspose2d} from '../src/conv_transpose2d.js';
+import {clamp} from '../src/clamp.js';
+import {leakyRelu} from '../src/leaky_relu.js';
+import {relu} from '../src/relu.js';
+import {sigmoid} from '../src/sigmoid.js';
+import {Tensor} from '../src/lib/tensor.js';
+
+import * as utils from './utils.js';
+
+describe('test convTranspose2d', function() {
+  function testConvTranspose2d(
+      input, filter, expected, options = {}, bias = undefined,
+      activation = undefined, fusion = false, activationOptions = {}) {
+    const inputTensor = new Tensor(input.shape, input.data);
+    const filterTensor = new Tensor(filter.shape, filter.data);
+    if (bias) {
+      options.bias = new Tensor(bias.shape, bias.data);
+    }
+    if (activation === 'relu') {
+      options.activation = relu;
+    } else if (activation === 'relu6') {
+      options.activation = utils.bindTrailingArgs(clamp, {minValue: 0, maxValue: 6});
+    } else if (activation === 'sigmoid') {
+      options.activation = sigmoid;
+    } else if (activation === 'leakyRelu') {
+      options.activation = utils.bindTrailingArgs(leakyRelu, activationOptions);
+    }
+
+    const outputTensor = convTranspose2d(inputTensor, filterTensor, options);
+    utils.checkShape(outputTensor, expected.shape);
+    utils.checkValue(outputTensor, expected.data);
+  }
+
+  it('convTranspose2d default options', function() {
+    const input = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const filter = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const expected = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 0, 1, 0, 4, 6, 4, 12, 9,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected);
+  });
+
+  it('convTranspose2d options.padding', function() {
+    const input = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const filter = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const options = {
+      padding: [1, 1, 1, 1],
+    };
+    const expected = {
+      shape: [1, 1, 1, 1],
+      data: [4],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.inputLayout=nchw', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      inputLayout: 'nchw',
+    };
+    const expected = {
+      shape: [1, 2, 5, 5],
+      data: [
+        0.,  1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36.,
+        27., 15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,  0.,
+        1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36., 27.,
+        15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.inputLayout=nhwc', function() {
+    const input = {
+      shape: [1, 3, 3, 1],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      inputLayout: 'nhwc',
+    };
+    const expected = {
+      shape: [1, 5, 5, 2],
+      data: [
+        0.,  0.,  1.,  1.,  3.,  3.,  3.,  3.,  2.,  2.,  3.,  3.,  8.,
+        8.,  15., 15., 12., 12., 7.,  7.,  9.,  9.,  21., 21., 36., 36.,
+        27., 27., 15., 15., 9.,  9.,  20., 20., 33., 33., 24., 24., 13.,
+        13., 6.,  6.,  13., 13., 21., 21., 15., 15., 8.,  8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.filterLayout=iohw', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      filterLayout: 'iohw',
+    };
+    const expected = {
+      shape: [1, 2, 5, 5],
+      data: [
+        0.,  1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36.,
+        27., 15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,  0.,
+        1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36., 27.,
+        15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.filterLayout=hwoi', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 2, 1],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 2, 5, 5],
+      data: [
+        0.,  1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36.,
+        27., 15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,  0.,
+        1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36., 27.,
+        15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.filterLayout=ohwi', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [2, 3, 3, 1],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      filterLayout: 'ohwi',
+    };
+    const expected = {
+      shape: [1, 2, 5, 5],
+      data: [
+        0.,  1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36.,
+        27., 15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,  0.,
+        1.,  3.,  3.,  2.,  3.,  8.,  15., 12., 7.,  9.,  21., 36., 27.,
+        15., 9.,  20., 33., 24., 13., 6.,  13., 21., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.strides', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 2, 1],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      strides: [3, 2],
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 2, 9, 7],
+      data: [
+        0., 0., 1.,  1., 3.,  2., 2.,
+        0., 0., 1.,  1., 3.,  2., 2.,
+        0., 0., 1.,  1., 3.,  2., 2.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        6., 6., 13., 7., 15., 8., 8.,
+        6., 6., 13., 7., 15., 8., 8.,
+        6., 6., 13., 7., 15., 8., 8.,
+        0., 0., 1.,  1., 3.,  2., 2.,
+        0., 0., 1.,  1., 3.,  2., 2.,
+        0., 0., 1.,  1., 3.,  2., 2.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        3., 3., 7.,  4., 9.,  5., 5.,
+        6., 6., 13., 7., 15., 8., 8.,
+        6., 6., 13., 7., 15., 8., 8.,
+        6., 6., 13., 7., 15., 8., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.outputSizes', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 2, 1],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      strides: [3, 2],
+      outputSizes: [10, 8],
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 2, 10, 8],
+      data: [
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        0., 0., 0.,  0., 0.,  0., 0., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        0., 0., 0.,  0., 0.,  0., 0., 0.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.outputPadding', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 2, 1],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      strides: [3, 2],
+      outputPadding: [1, 1],
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 2, 10, 8],
+      data: [
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        0., 0., 0.,  0., 0.,  0., 0., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        0., 0., 1.,  1., 3.,  2., 2., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        3., 3., 7.,  4., 9.,  5., 5., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        6., 6., 13., 7., 15., 8., 8., 0.,
+        0., 0., 0.,  0., 0.,  0., 0., 0.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.autoPad=explicit options.padding', function() {
+    const input = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const filter = {
+      shape: [1, 1, 2, 2],
+      data: [
+        0,  1,  2,  3,
+      ],
+    };
+    const options = {
+      padding: [1, 1, 1, 1],
+      autoPad: 'explicit',
+    };
+    const expected = {
+      shape: [1, 1, 1, 1],
+      data: [4],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.autoPad=same-upper', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      strides: [2, 2],
+      autoPad: 'same-upper',
+    };
+    const expected = {
+      shape: [1, 2, 6, 6],
+      data: [
+        0., 0.,  1.,  1.,  3.,  2.,  0., 0.,  1.,  1., 3.,  2.,  3.,  3.,  8.,
+        5., 12., 7.,  3.,  3.,  7.,  4., 9.,  5.,  9., 9.,  20., 11., 24., 13.,
+        6., 6.,  13., 7.,  15., 8.,  0., 0.,  1.,  1., 3.,  2.,  0.,  0.,  1.,
+        1., 3.,  2.,  3.,  3.,  8.,  5., 12., 7.,  3., 3.,  7.,  4.,  9.,  5.,
+        9., 9.,  20., 11., 24., 13., 6., 6.,  13., 7., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.autoPad=same-upper ignored options.padding', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      padding: [1, 1, 1, 1],
+      strides: [2, 2],
+      autoPad: 'same-upper',
+    };
+    const expected = {
+      shape: [1, 2, 6, 6],
+      data: [
+        0., 0.,  1.,  1.,  3.,  2.,  0., 0.,  1.,  1., 3.,  2.,  3.,  3.,  8.,
+        5., 12., 7.,  3.,  3.,  7.,  4., 9.,  5.,  9., 9.,  20., 11., 24., 13.,
+        6., 6.,  13., 7.,  15., 8.,  0., 0.,  1.,  1., 3.,  2.,  0.,  0.,  1.,
+        1., 3.,  2.,  3.,  3.,  8.,  5., 12., 7.,  3., 3.,  7.,  4.,  9.,  5.,
+        9., 9.,  20., 11., 24., 13., 6., 6.,  13., 7., 15., 8.,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.autoPad=same-lower', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      strides: [2, 2],
+      autoPad: 'same-lower',
+    };
+    const expected = {
+      shape: [1, 2, 6, 6],
+      data: [
+        0, 1, 1, 3, 2, 2,
+        3, 8, 5, 12, 7, 7,
+        3, 7, 4, 9, 5, 5,
+        9, 20, 11, 24, 13, 13,
+        6, 13, 7, 15, 8, 8,
+        6, 13, 7, 15, 8, 8,
+        0, 1, 1, 3, 2, 2,
+        3, 8, 5, 12, 7, 7,
+        3, 7, 4, 9, 5, 5,
+        9, 20, 11, 24, 13, 13,
+        6, 13, 7, 15, 8, 8,
+        6, 13, 7, 15, 8, 8,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.autoPad=same-lower ignored options.padding', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [1, 2, 3, 3],
+      data: new Array(18).fill(1),
+    };
+    const options = {
+      padding: [1, 1, 1, 1],
+      strides: [2, 2],
+      autoPad: 'same-lower',
+    };
+    const expected = {
+      shape: [1, 2, 6, 6],
+      data: [
+        0, 1, 1, 3, 2, 2,
+        3, 8, 5, 12, 7, 7,
+        3, 7, 4, 9, 5, 5,
+        9, 20, 11, 24, 13, 13,
+        6, 13, 7, 15, 8, 8,
+        6, 13, 7, 15, 8, 8,
+        0, 1, 1, 3, 2, 2,
+        3, 8, 5, 12, 7, 7,
+        3, 7, 4, 9, 5, 5,
+        9, 20, 11, 24, 13, 13,
+        6, 13, 7, 15, 8, 8,
+        6, 13, 7, 15, 8, 8,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d options.dilations', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 1, 1],
+      data: new Array(9).fill(1),
+    };
+    const options = {
+      strides: [2, 2],
+      dilations: [2, 2],
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 1, 9, 9],
+      data: [
+        0, 0, 1, 0, 3, 0, 3, 0, 2,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        3, 0, 8, 0, 15, 0, 12, 0, 7,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        9, 0, 21, 0, 36, 0, 27, 0, 15,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        9, 0, 20, 0, 33, 0, 24, 0, 13,
+        0, 0, 0, 0, 0, 0, 0, 0, 0,
+        6, 0, 13, 0, 21, 0, 15, 0, 8,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options);
+  });
+
+  it('convTranspose2d bias', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 1, 1],
+      data: new Array(9).fill(1),
+    };
+    const bias = {
+      shape: [1],
+      data: [1],
+    };
+    const options = {
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 1, 5, 5],
+      data: [
+        1, 2, 4, 4, 3, 4, 9, 16, 13, 8,
+        10, 22, 37, 28, 16, 10, 21, 34, 25, 14,
+        7, 14, 22, 16, 9,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options, bias);
+  });
+
+  it('convTranspose2d activation', function() {
+    const input = {
+      shape: [1, 1, 3, 3],
+      data: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8,
+      ],
+    };
+    const filter = {
+      shape: [3, 3, 1, 1],
+      data: new Array(9).fill(1),
+    };
+    const options = {
+      inputLayout: 'nchw',
+      filterLayout: 'hwoi',
+    };
+    const expected = {
+      shape: [1, 1, 5, 5],
+      data: [
+        0, 1, 3, 3, 2, 3, 8, 15, 12, 7,
+        9, 21, 36, 27, 15, 9, 20, 33, 24, 13,
+        6, 13, 21, 15, 8,
+      ],
+    };
+    testConvTranspose2d(input, filter, expected, options, undefined, 'relu');
+  });
+});

--- a/test/conv_transpose2d_test.js
+++ b/test/conv_transpose2d_test.js
@@ -493,34 +493,35 @@ describe('test convTranspose2d', function() {
   });
 
   it('convTranspose2d options.dilations', function() {
+    // this test is from ONNX
+    //   https://github.com/onnx/onnx/blob/main/onnx/backend/test/case/node/convtranspose.py#L328
     const input = {
       shape: [1, 1, 3, 3],
       data: [
-        0, 1, 2, 3, 4, 5, 6, 7, 8,
+        3.0, 8.0, 1.0,
+        9.0, 5.0, 7.0,
+        3.0, 2.0, 6.0,
       ],
     };
     const filter = {
-      shape: [3, 3, 1, 1],
-      data: new Array(9).fill(1),
+      shape: [2, 2, 1, 1],
+      data: [
+        7.0, 2.0,
+        1.0, 9.0,
+      ],
     };
     const options = {
-      strides: [2, 2],
       dilations: [2, 2],
-      inputLayout: 'nchw',
       filterLayout: 'hwoi',
     };
     const expected = {
-      shape: [1, 1, 9, 9],
+      shape: [1, 1, 5, 5],
       data: [
-        0, 0, 1, 0, 3, 0, 3, 0, 2,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
-        3, 0, 8, 0, 15, 0, 12, 0, 7,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
-        9, 0, 21, 0, 36, 0, 27, 0, 15,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
-        9, 0, 20, 0, 33, 0, 24, 0, 13,
-        0, 0, 0, 0, 0, 0, 0, 0, 0,
-        6, 0, 13, 0, 21, 0, 15, 0, 8,
+        21.0, 56.0, 13.0, 16.0, 2.0,
+        63.0, 35.0, 67.0, 10.0, 14.0,
+        24.0, 22.0, 76.0, 76.0, 21.0,
+        9.0, 5.0, 88.0, 45.0, 63.0,
+        3.0, 2.0, 33.0, 18.0, 54.0,
       ],
     };
     testConvTranspose2d(input, filter, expected, options);


### PR DESCRIPTION
fix #10
@huningxin @fdwr I use **conv2d** logic to compute **convTranspose2d** with padding input of **convTranspose2d**, PTAL, thanks.

About implementation of **dilation** part, I refer to [PyTorch CONVTRANSPOSE2D](https://pytorch.org/docs/stable/generated/torch.nn.ConvTranspose2d.html), and verify the implementation by [an ONNX's  convTranspose2d test](https://github.com/onnx/onnx/blob/main/onnx/backend/test/case/node/convtranspose.py#L328).